### PR TITLE
Rescale and Recenter Axis

### DIFF
--- a/examples/AxisSymmetry/AxisSymmetry.ino
+++ b/examples/AxisSymmetry/AxisSymmetry.ino
@@ -1,0 +1,68 @@
+/*
+ *  Project     Controller Utilities Library
+ *  @author     David Madison
+ *  @link       github.com/dmadison/CtrlUtil
+ *  @license    MIT - Copyright (c) 2022 David Madison
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ *  Example:      AxisSymmetry
+ *  Description:  Takes an analog input (like a joystick) with two unequal
+ *                (asymmetrical) ranges and rescales the output so that it
+ *                smoothly covers an entire range.
+ * 
+ *                This is designed to be used when you have a joystick that has 
+ *                more range on one side than the other. This lets you make use
+ *                of the full range of the joystick without doing anything
+ *                special to the output.
+ *
+ *                If you want to add a deadzone to this, the deadzone should be
+ *                applied *after* this fix.
+ */
+
+#include <CtrlUtil.h>
+
+const int InputPin = A0;
+
+const int InputMin    = 0;    // lower end of the axis range
+const int InputCenter = 400;  // center of the axis range, where the joysick rests
+const int InputMax    = 1023; // max end of the axis range
+
+const int OutputMin = 0;     // output value of the function, min
+const int OutputMax = 1023;  // output value of the function, max
+
+void setup() {
+	Serial.begin(115200);
+
+	pinMode(InputPin, INPUT);
+}
+
+void loop() {
+	int rawValue = analogRead(InputPin);
+	int symValue = fixAxisSymmetry(rawValue, InputMin, InputCenter, InputMax, OutputMin, OutputMax);
+
+	Serial.print("Raw: ");
+	Serial.print(rawValue);
+	Serial.print('\t');
+	Serial.print("Symmetric: ");
+	Serial.print(symValue);
+	Serial.println();
+
+	delay(100);
+}

--- a/examples/RecenterAxis/RecenterAxis.ino
+++ b/examples/RecenterAxis/RecenterAxis.ino
@@ -22,17 +22,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  * 
- *  Example:      AxisSymmetry
- *  Description:  Takes an analog input (like a joystick) with two unequal
- *                (asymmetrical) ranges and rescales the output so that it
- *                smoothly covers an entire range.
+ *  Example:      RecenterAxis
+ *  Description:  Takes an analog input (like a joystick) with an uncentered
+ *                midpoint and unequal (asymmetrical) ranges and rescales the
+ *                output so that the midpoint is in the dead center of the
+ *                desired output range.
  * 
  *                This is designed to be used when you have a joystick that has 
  *                more range on one side than the other. This lets you make use
  *                of the full range of the joystick without doing anything
  *                special to the output.
+ * 
+ *                If your joystick has drift, try to fix it with a deadzone
+ *                instead of using this function.
  *
- *                If you want to add a deadzone to this, the deadzone should be
+ *                If you want to add a deadzone, the deadzone should be
  *                applied *after* this fix.
  */
 
@@ -55,7 +59,7 @@ void setup() {
 
 void loop() {
 	int rawValue = analogRead(InputPin);
-	int symValue = fixAxisSymmetry(rawValue, InputMin, InputCenter, InputMax, OutputMin, OutputMax);
+	int symValue = recenterAxis(rawValue, InputMin, InputCenter, InputMax, OutputMin, OutputMax);
 
 	Serial.print("Raw: ");
 	Serial.print(rawValue);

--- a/keywords.txt
+++ b/keywords.txt
@@ -20,6 +20,7 @@ DeadzoneFilterType	KEYWORD1
 # Standalone Functions
 remap	KEYWORD2
 invertAxis	KEYWORD2
+fixAxisSymmetry	KEYWORD2
 
 # DeadzoneFilter
 filter	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -18,6 +18,7 @@ DeadzoneFilterType	KEYWORD1
 #######################################
 
 # Standalone Functions
+remap	KEYWORD2
 invertAxis	KEYWORD2
 
 # DeadzoneFilter

--- a/keywords.txt
+++ b/keywords.txt
@@ -20,7 +20,7 @@ DeadzoneFilterType	KEYWORD1
 # Standalone Functions
 remap	KEYWORD2
 invertAxis	KEYWORD2
-fixAxisSymmetry	KEYWORD2
+recenterAxis	KEYWORD2
 
 # DeadzoneFilter
 filter	KEYWORD2

--- a/src/CtrlUtil.cpp
+++ b/src/CtrlUtil.cpp
@@ -1,0 +1,34 @@
+/*
+ *  Project     Controller Utilities Library
+ *  @author     David Madison
+ *  @link       github.com/dmadison/CtrlUtil
+ *  @license    MIT - Copyright (c) 2022 David Madison
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "CtrlUtil.h"
+
+long remap(long value, long inMin, long inMax, long outMin, long outMax)
+{
+	if (value <= inMin) return outMin;  // below min threshold
+	if (value >= inMax) return outMax;  // above max threshold
+	return (value - inMin) * (outMax - outMin) / (inMax - inMin) + outMin;  // otherwise, rescale
+}

--- a/src/CtrlUtil.h
+++ b/src/CtrlUtil.h
@@ -49,7 +49,7 @@ constexpr T invertAxis(T value)
 
 
 template <typename T>
-T fixAxisSymmetry(T value, T inMin, T inCenter, T inMax, T outMin, T outMax)
+T recenterAxis(T value, T inMin, T inCenter, T inMax, T outMin, T outMax)
 {
 	// sort input range values so min is lower than max
 	if (inMin > inMax) {

--- a/src/CtrlUtil.h
+++ b/src/CtrlUtil.h
@@ -49,6 +49,33 @@ constexpr T invertAxis(T value)
 
 
 template <typename T>
+T fixAxisSymmetry(T value, T inMin, T inCenter, T inMax, T outMin, T outMax)
+{
+	// sort input range values so min is lower than max
+	if (inMin > inMax) {
+		T temp = inMin;
+		inMin = inMax;
+		inMax = temp;
+	}
+
+	// quit if center is out of range
+	if (inCenter < inMin || inCenter > inMax) return value;
+
+	// calculate output center for range checks
+	const long outCenter = (long) (outMin + outMax) / 2;
+
+	// evaluate range for lower range
+	if (value <= inCenter) {
+		return remap(value, inMin, inCenter, outMin, outCenter);
+	}
+	// otherwise, evaluate range for upper range
+	else {
+		return remap(value, inCenter, inMax, outCenter, outMax);
+	}
+}
+
+
+template <typename T>
 class DeadzoneFilterType {
 public:
 	enum Alignment : uint8_t {

--- a/src/CtrlUtil.h
+++ b/src/CtrlUtil.h
@@ -29,6 +29,8 @@
 
 #include <stdint.h>
 
+long remap(long value, long inMin, long inMax, long outMin, long outMax);
+
 
 template <typename T>
 constexpr T invertAxis(T value, T adc_min, T adc_max)

--- a/src/CtrlUtil.h
+++ b/src/CtrlUtil.h
@@ -77,13 +77,13 @@ public:
 			if (input > deadzoneThreshold)
 				output = outMax;  // in deadzone, output top of range
 			else
-				output = map(input, rangeMin, deadzoneThreshold, outMin, outMax);
+				output = remap(input, rangeMin, deadzoneThreshold, outMin, outMax);
 			break;
 		case(Alignment::Bottom):
 			if (input < deadzoneThreshold)
 				output = outMin;  // in deadzone, output bottom of range
 			else
-				output = map(input, deadzoneThreshold, rangeMax, outMin, outMax);
+				output = remap(input, deadzoneThreshold, rangeMax, outMin, outMax);
 			break;
 		case(Alignment::Middle):
 		{
@@ -92,9 +92,9 @@ public:
 			const long outCenter = (outMin + outMax) / 2;
 
 			if (input < thresholdLow)
-				output = map(input, rangeMin, thresholdLow, outMin, outCenter);  // low, remap to lower half
+				output = remap(input, rangeMin, thresholdLow, outMin, outCenter);  // low, remap to lower half
 			else if (input > thresholdHigh)
-				output = map(input, thresholdHigh, rangeMax, outCenter, outMax);  // high, remap to upper half
+				output = remap(input, thresholdHigh, rangeMax, outCenter, outMax);  // high, remap to upper half
 			else
 				output = outCenter;  // in deadzone, output center
 			break;


### PR DESCRIPTION
This creates a `remap()` function to use in place of the Arduino `map()`. This removes a dependency and limits the output to the provided output ranges.

It also adds a `recenterAxis()` function that rescales an axis with an uncentered midpoint (two unequal ranges) so that the midpoint rests in the center of the axis. This is useful if you have a joystick (or other axis) that has more range of motion on one side than another.

Whereas a simple range function would truncate the values to the lower portion of the range and leave the center askew (causing "drift"), this rescales the output based on its location relative to the provided center. By recentering, you can use the entire available range of motion out of the joystick, but still pass it to an output function as if the entire range is present.